### PR TITLE
Use context.theme.textTheme.button instead of context.theme.textTheme…

### DIFF
--- a/lib/src/widgets/separated_buttons.dart
+++ b/lib/src/widgets/separated_buttons.dart
@@ -20,7 +20,7 @@ class SeparatedButtons extends StatelessWidget {
       children: <Widget>[
         for (final child in children.withoutLast()) ...[
           child,
-          Text('⋅', style: context.theme.textTheme.headline5),
+          Text('⋅', style: context.theme.textTheme.button),
         ],
         children.last,
       ],


### PR DESCRIPTION
Fixes: #3
….headline5 for the separating dots

<!-- Please enter the corresponding issue ID: -->
**Fixes: #Issue**

<!-- Add the breaking label (PR: BREAKING) if applicable. -->


**Checklist**
<!-- Please check if your PR fulfills the following requirements: -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Changes**
<!-- Please summarize your changes -->



<!-- Add this section if you need it.
**Screenshots**

| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
